### PR TITLE
WE-44: Update git-commit-id-maven-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,28 +183,6 @@
                     <useNativeGitViaCommandLine>true</useNativeGitViaCommandLine>
                 </configuration>
             </plugin>
-			<!-- <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.9.10</version>			
-                    <executions>
-                        <execution>
-                            <id>get-the-git-infos</id>
-                            <goals>
-                                <goal>revision</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>validate-the-git-infos</id>
-                            <goals>
-                                <goal>validateRevision</goal>
-                            </goals>
-                        </execution>
-                    </executions>                
-                <configuration>
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
-                </configuration>
-			</plugin> -->
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -179,8 +179,32 @@
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                     <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <useNativeGitViaCommandLine>true</useNativeGitViaCommandLine>
                 </configuration>
             </plugin>
+			<!-- <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.9.10</version>			
+                    <executions>
+                        <execution>
+                            <id>get-the-git-infos</id>
+                            <goals>
+                                <goal>revision</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>validate-the-git-infos</id>
+                            <goals>
+                                <goal>validateRevision</goal>
+                            </goals>
+                        </execution>
+                    </executions>                
+                <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
+			</plugin> -->
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Fix maven plugin configuration to not fail when `.git` directory is not present.